### PR TITLE
쓰레기통 내용물 추가 API

### DIFF
--- a/src/main/java/com/bigbro/killbill/v1/api/trash/can/TrashCanContentsApi.java
+++ b/src/main/java/com/bigbro/killbill/v1/api/trash/can/TrashCanContentsApi.java
@@ -1,0 +1,30 @@
+package com.bigbro.killbill.v1.api.trash.can;
+
+import com.bigbro.killbill.v1.common.KillBillResponse;
+import com.bigbro.killbill.v1.common.KillBillResponseUtil;
+import com.bigbro.killbill.v1.domain.request.trash.can.TrashCanContentsRequest;
+import com.bigbro.killbill.v1.service.trash.can.TrashCanContentsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/v1/trash-can-contents")
+@RequiredArgsConstructor
+public class TrashCanContentsApi {
+
+    private final TrashCanContentsService trashCanContentsService;
+
+    @PostMapping
+    public ResponseEntity<KillBillResponse<Void>> createTrashCanContents(@RequestBody @Valid TrashCanContentsRequest trashCanContentsRequest) {
+        // TODO : UserId 넣기
+        trashCanContentsService.createTrashCanContents(trashCanContentsRequest, 1L);
+
+        return KillBillResponseUtil.responseCreatedNoData();
+    }
+}

--- a/src/main/java/com/bigbro/killbill/v1/domain/entity/trash/TrashCanContents.java
+++ b/src/main/java/com/bigbro/killbill/v1/domain/entity/trash/TrashCanContents.java
@@ -1,0 +1,42 @@
+package com.bigbro.killbill.v1.domain.entity.trash;
+
+import com.bigbro.killbill.v1.domain.entity.base.BaseEntity;
+import com.bigbro.killbill.v1.domain.entity.user.User;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.Comment;
+
+import javax.persistence.*;
+
+/**
+ * 쓰레기통 로그를 이용 안하고 별도로 쓰레기통 내용물 테이블을 둔 이유
+ * 로그를 이용하게 될 경우 이미 비워진 쓰레기 내용물까지 포함하고 있어
+ * 나중에 많은 쓰레기 로그가 존재할 경우 조회 성능에 문제 생길걸 대비하여 현 쓰레기통 상태값 만을 위한 값을 별도로 둠.
+ */
+
+@Entity
+@Table(name = "trash_can_contents")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class TrashCanContents extends BaseEntity {
+
+    @Id
+    @Column(name = "trash_can_contents_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long trashCanContentsId;
+
+    @Comment("버린 쓰레기 수")
+    @Column(name = "trash_count")
+    private Long trashCount;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @OneToOne
+    @JoinColumn(name = "trash_info_id")
+    private TrashInfo trashInfo;
+}

--- a/src/main/java/com/bigbro/killbill/v1/domain/entity/trash/TrashCanContents.java
+++ b/src/main/java/com/bigbro/killbill/v1/domain/entity/trash/TrashCanContents.java
@@ -13,7 +13,8 @@ import javax.persistence.*;
 /**
  * 쓰레기통 로그를 이용 안하고 별도로 쓰레기통 내용물 테이블을 둔 이유
  * 로그를 이용하게 될 경우 이미 비워진 쓰레기 내용물까지 포함하고 있어
- * 나중에 많은 쓰레기 로그가 존재할 경우 조회 성능에 문제 생길걸 대비하여 현 쓰레기통 상태값 만을 위한 값을 별도로 둠.
+ * 나중에 많은 쓰레기 로그가 존재할 경우 조회 성능에 문제 생길걸 대비하여
+ * 현 쓰레기통 상태값 만을 위한 값을 별도로 둠.
  */
 
 @Entity
@@ -39,4 +40,12 @@ public class TrashCanContents extends BaseEntity {
     @OneToOne
     @JoinColumn(name = "trash_info_id")
     private TrashInfo trashInfo;
+
+    public static TrashCanContents of(TrashInfo trashInfo, User user, Long trashCount) {
+        return TrashCanContents.builder()
+                .trashCount(trashCount)
+                .user(user)
+                .trashInfo(trashInfo)
+                .build();
+    }
 }

--- a/src/main/java/com/bigbro/killbill/v1/domain/entity/trash/TrashCategory.java
+++ b/src/main/java/com/bigbro/killbill/v1/domain/entity/trash/TrashCategory.java
@@ -23,7 +23,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SuperBuilder
 @Getter
-public class TrashCategoryEntity extends BaseEntity {
+public class TrashCategory extends BaseEntity {
 
     @Id
     @Column(name = "trash_category_id")
@@ -34,8 +34,8 @@ public class TrashCategoryEntity extends BaseEntity {
     @Column(name = "trash_category_name")
     private String trashCategoryName;
 
-    public static TrashCategoryEntity from(TrashCategoryRequest trashCategoryRequest) {
-        return TrashCategoryEntity.builder()
+    public static TrashCategory from(TrashCategoryRequest trashCategoryRequest) {
+        return TrashCategory.builder()
                 .trashCategoryName(trashCategoryRequest.getCategoryName())
                 .build();
     }

--- a/src/main/java/com/bigbro/killbill/v1/domain/entity/trash/TrashInfo.java
+++ b/src/main/java/com/bigbro/killbill/v1/domain/entity/trash/TrashInfo.java
@@ -15,7 +15,7 @@ import javax.persistence.*;
 @SuperBuilder
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class TrashInfoEntity extends BaseEntity {
+public class TrashInfo extends BaseEntity {
 
     @Id
     @Column(name = "trash_info_id")
@@ -44,16 +44,16 @@ public class TrashInfoEntity extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "trash_category_id")
-    private TrashCategoryEntity trashCategoryEntity;
+    private TrashCategory trashCategory;
 
-    public static TrashInfoEntity of(TrashInfoRequest trashInfoRequest, TrashCategoryEntity trashCategoryEntity) {
-        return TrashInfoEntity.builder()
+    public static TrashInfo of(TrashInfoRequest trashInfoRequest, TrashCategory trashCategory) {
+        return TrashInfo.builder()
                 .name(trashInfoRequest.getName())
                 .size(trashInfoRequest.getSize())
                 .weight(trashInfoRequest.getWeight())
                 .carbonEmissionPerGram(trashInfoRequest.getCarbonEmissionPerGram())
                 .refund(trashInfoRequest.getRefund())
-                .trashCategoryEntity(trashCategoryEntity)
+                .trashCategory(trashCategory)
                 .build();
     }
 

--- a/src/main/java/com/bigbro/killbill/v1/domain/entity/user/User.java
+++ b/src/main/java/com/bigbro/killbill/v1/domain/entity/user/User.java
@@ -14,9 +14,10 @@ import javax.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @SuperBuilder
-public class UserEntity extends BaseEntity {
+public class User extends BaseEntity {
 
     @Id
+    @Column(name = "user_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userId;
 

--- a/src/main/java/com/bigbro/killbill/v1/domain/request/trash/can/TrashCanContentsRequest.java
+++ b/src/main/java/com/bigbro/killbill/v1/domain/request/trash/can/TrashCanContentsRequest.java
@@ -1,0 +1,19 @@
+package com.bigbro.killbill.v1.domain.request.trash.can;
+
+import lombok.*;
+
+import javax.validation.constraints.NotNull;
+
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrashCanContentsRequest {
+
+    @NotNull(message = "쓰레기 이름은 필수입니다.")
+    private Long trashCount;
+
+    @NotNull(message = "쓰레기 정보 ID는 필수입니다.")
+    private Long trashInfoId;
+
+}

--- a/src/main/java/com/bigbro/killbill/v1/domain/response/trash/TrashCategoryResponse.java
+++ b/src/main/java/com/bigbro/killbill/v1/domain/response/trash/TrashCategoryResponse.java
@@ -1,6 +1,6 @@
 package com.bigbro.killbill.v1.domain.response.trash;
 
-import com.bigbro.killbill.v1.domain.entity.trash.TrashCategoryEntity;
+import com.bigbro.killbill.v1.domain.entity.trash.TrashCategory;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,10 +15,10 @@ public class TrashCategoryResponse {
 
     private String trashCategoryName;
 
-    public static TrashCategoryResponse from(TrashCategoryEntity trashCategoryEntity) {
+    public static TrashCategoryResponse from(TrashCategory trashCategory) {
         return TrashCategoryResponse.builder()
-                .trashCategoryId(trashCategoryEntity.getTrashCategoryId())
-                .trashCategoryName(trashCategoryEntity.getTrashCategoryName())
+                .trashCategoryId(trashCategory.getTrashCategoryId())
+                .trashCategoryName(trashCategory.getTrashCategoryName())
                 .build();
     }
 }

--- a/src/main/java/com/bigbro/killbill/v1/domain/response/trash/TrashInfoResponse.java
+++ b/src/main/java/com/bigbro/killbill/v1/domain/response/trash/TrashInfoResponse.java
@@ -1,13 +1,10 @@
 package com.bigbro.killbill.v1.domain.response.trash;
 
-import com.bigbro.killbill.v1.domain.entity.trash.TrashCategoryEntity;
-import com.bigbro.killbill.v1.domain.entity.trash.TrashInfoEntity;
+import com.bigbro.killbill.v1.domain.entity.trash.TrashInfo;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.util.List;
 
 @Builder
 @Getter
@@ -31,14 +28,14 @@ public class TrashInfoResponse {
     // 환불 금액
     private Integer refund;
 
-    public static TrashInfoResponse from(TrashInfoEntity trashInfoEntity) {
+    public static TrashInfoResponse from(TrashInfo trashInfo) {
         return TrashInfoResponse.builder()
-                .trashInfoId(trashInfoEntity.getTrashInfoId())
-                .name(trashInfoEntity.getName())
-                .size(trashInfoEntity.getSize())
-                .weight(trashInfoEntity.getWeight())
-                .carbonEmissionPerGram(trashInfoEntity.getCarbonEmissionPerGram())
-                .refund(trashInfoEntity.getRefund())
+                .trashInfoId(trashInfo.getTrashInfoId())
+                .name(trashInfo.getName())
+                .size(trashInfo.getSize())
+                .weight(trashInfo.getWeight())
+                .carbonEmissionPerGram(trashInfo.getCarbonEmissionPerGram())
+                .refund(trashInfo.getRefund())
                 .build();
     }
 }

--- a/src/main/java/com/bigbro/killbill/v1/repository/trash/can/TrashCanContentsRepository.java
+++ b/src/main/java/com/bigbro/killbill/v1/repository/trash/can/TrashCanContentsRepository.java
@@ -1,0 +1,7 @@
+package com.bigbro.killbill.v1.repository.trash.can;
+
+import com.bigbro.killbill.v1.domain.entity.trash.TrashCanContents;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TrashCanContentsRepository extends JpaRepository<TrashCanContents, Long> {
+}

--- a/src/main/java/com/bigbro/killbill/v1/repository/trash/category/TrashCategoryRepository.java
+++ b/src/main/java/com/bigbro/killbill/v1/repository/trash/category/TrashCategoryRepository.java
@@ -1,7 +1,7 @@
 package com.bigbro.killbill.v1.repository.trash.category;
 
-import com.bigbro.killbill.v1.domain.entity.trash.TrashCategoryEntity;
+import com.bigbro.killbill.v1.domain.entity.trash.TrashCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TrashCategoryRepository extends JpaRepository<TrashCategoryEntity, Long> {
+public interface TrashCategoryRepository extends JpaRepository<TrashCategory, Long> {
 }

--- a/src/main/java/com/bigbro/killbill/v1/repository/trash/info/TrashInfoRepository.java
+++ b/src/main/java/com/bigbro/killbill/v1/repository/trash/info/TrashInfoRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface TrashInfoRepository extends JpaRepository<TrashInfo, Long> {
-    List<TrashInfo> findTrashInfoEntitiesByTrashCategoryId(TrashCategory trashCategory);
+    List<TrashInfo> findTrashInfoEntitiesByTrashCategory(TrashCategory trashCategory);
 }

--- a/src/main/java/com/bigbro/killbill/v1/repository/trash/info/TrashInfoRepository.java
+++ b/src/main/java/com/bigbro/killbill/v1/repository/trash/info/TrashInfoRepository.java
@@ -1,11 +1,11 @@
 package com.bigbro.killbill.v1.repository.trash.info;
 
-import com.bigbro.killbill.v1.domain.entity.trash.TrashCategoryEntity;
-import com.bigbro.killbill.v1.domain.entity.trash.TrashInfoEntity;
+import com.bigbro.killbill.v1.domain.entity.trash.TrashCategory;
+import com.bigbro.killbill.v1.domain.entity.trash.TrashInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface TrashInfoRepository extends JpaRepository<TrashInfoEntity, Long> {
-    List<TrashInfoEntity> findTrashInfoEntitiesByTrashCategoryEntity(TrashCategoryEntity trashCategoryEntity);
+public interface TrashInfoRepository extends JpaRepository<TrashInfo, Long> {
+    List<TrashInfo> findTrashInfoEntitiesByTrashCategoryId(TrashCategory trashCategory);
 }

--- a/src/main/java/com/bigbro/killbill/v1/repository/user/UserRepository.java
+++ b/src/main/java/com/bigbro/killbill/v1/repository/user/UserRepository.java
@@ -1,0 +1,8 @@
+package com.bigbro.killbill.v1.repository.user;
+
+
+import com.bigbro.killbill.v1.domain.entity.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/bigbro/killbill/v1/service/trash/can/TrashCanContentsService.java
+++ b/src/main/java/com/bigbro/killbill/v1/service/trash/can/TrashCanContentsService.java
@@ -1,0 +1,12 @@
+package com.bigbro.killbill.v1.service.trash.can;
+
+import com.bigbro.killbill.v1.domain.request.trash.can.TrashCanContentsRequest;
+
+public interface TrashCanContentsService {
+
+    /**
+     * 쓰레기 버리기
+     * @param trashCanContentsRequest 쓰레기 정보 ID, 쓰레기 수
+     */
+    void createTrashCanContents(TrashCanContentsRequest trashCanContentsRequest, Long userId);
+}

--- a/src/main/java/com/bigbro/killbill/v1/service/trash/impl/TrashCanContentsServiceImpl.java
+++ b/src/main/java/com/bigbro/killbill/v1/service/trash/impl/TrashCanContentsServiceImpl.java
@@ -1,0 +1,36 @@
+package com.bigbro.killbill.v1.service.trash.impl;
+
+import com.bigbro.killbill.v1.common.KillBillResponseCode;
+import com.bigbro.killbill.v1.domain.entity.trash.TrashCanContents;
+import com.bigbro.killbill.v1.domain.entity.trash.TrashInfo;
+import com.bigbro.killbill.v1.domain.entity.user.User;
+import com.bigbro.killbill.v1.domain.request.trash.can.TrashCanContentsRequest;
+import com.bigbro.killbill.v1.exception.DataNotFoundException;
+import com.bigbro.killbill.v1.repository.trash.can.TrashCanContentsRepository;
+import com.bigbro.killbill.v1.repository.trash.info.TrashInfoRepository;
+import com.bigbro.killbill.v1.repository.user.UserRepository;
+import com.bigbro.killbill.v1.service.trash.can.TrashCanContentsService;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrashCanContentsServiceImpl implements TrashCanContentsService {
+
+    private final UserRepository userRepository;
+
+    private final TrashInfoRepository trashInfoRepository;
+
+    private final TrashCanContentsRepository trashCanContentsRepository;
+
+    @Override
+    @Transactional
+    public void createTrashCanContents(TrashCanContentsRequest trashCanContentsRequest, Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new DataNotFoundException(KillBillResponseCode.NOT_FOUND_DATA, "존재하지 않는 유저입니다."));
+        TrashInfo trashInfo = trashInfoRepository.findById(trashCanContentsRequest.getTrashInfoId()).orElseThrow(() -> new DataNotFoundException(KillBillResponseCode.NOT_FOUND_DATA, "존재하지 않는 쓰레기 정보 입니다."));
+
+        trashCanContentsRepository.save(TrashCanContents.of(trashInfo, user, trashCanContentsRequest.getTrashCount()));
+    }
+}

--- a/src/main/java/com/bigbro/killbill/v1/service/trash/impl/TrashCanContentsServiceImpl.java
+++ b/src/main/java/com/bigbro/killbill/v1/service/trash/impl/TrashCanContentsServiceImpl.java
@@ -31,6 +31,7 @@ public class TrashCanContentsServiceImpl implements TrashCanContentsService {
         User user = userRepository.findById(userId).orElseThrow(() -> new DataNotFoundException(KillBillResponseCode.NOT_FOUND_DATA, "존재하지 않는 유저입니다."));
         TrashInfo trashInfo = trashInfoRepository.findById(trashCanContentsRequest.getTrashInfoId()).orElseThrow(() -> new DataNotFoundException(KillBillResponseCode.NOT_FOUND_DATA, "존재하지 않는 쓰레기 정보 입니다."));
 
+        // TODO : 쓰레기 로그 테이블 생성 후 로그도 저장 로직 추가
         trashCanContentsRepository.save(TrashCanContents.of(trashInfo, user, trashCanContentsRequest.getTrashCount()));
     }
 }

--- a/src/main/java/com/bigbro/killbill/v1/service/trash/impl/TrashCategoryServiceImpl.java
+++ b/src/main/java/com/bigbro/killbill/v1/service/trash/impl/TrashCategoryServiceImpl.java
@@ -1,6 +1,6 @@
 package com.bigbro.killbill.v1.service.trash.impl;
 
-import com.bigbro.killbill.v1.domain.entity.trash.TrashCategoryEntity;
+import com.bigbro.killbill.v1.domain.entity.trash.TrashCategory;
 import com.bigbro.killbill.v1.domain.request.trash.category.TrashCategoryRequest;
 import com.bigbro.killbill.v1.domain.response.trash.TrashCategoryResponse;
 import com.bigbro.killbill.v1.repository.trash.category.TrashCategoryRepository;
@@ -22,13 +22,13 @@ public class TrashCategoryServiceImpl implements TrashCategoryService {
     @Override
     @Transactional(readOnly = true)
     public List<TrashCategoryResponse> getTrashCategories() {
-        List<TrashCategoryEntity> trashCategoryResponses = trashCategoryRepository.findAll();
+        List<TrashCategory> trashCategoryResponses = trashCategoryRepository.findAll();
         return trashCategoryResponses.stream().map(TrashCategoryResponse::from).toList();
     }
 
     @Override
     @Transactional
     public void createTrashCategory(TrashCategoryRequest trashCategoryRequest) {
-        trashCategoryRepository.save(TrashCategoryEntity.from(trashCategoryRequest));
+        trashCategoryRepository.save(TrashCategory.from(trashCategoryRequest));
     }
 }

--- a/src/main/java/com/bigbro/killbill/v1/service/trash/impl/TrashInfoServiceImpl.java
+++ b/src/main/java/com/bigbro/killbill/v1/service/trash/impl/TrashInfoServiceImpl.java
@@ -1,8 +1,8 @@
 package com.bigbro.killbill.v1.service.trash.impl;
 
 import com.bigbro.killbill.v1.common.KillBillResponseCode;
-import com.bigbro.killbill.v1.domain.entity.trash.TrashCategoryEntity;
-import com.bigbro.killbill.v1.domain.entity.trash.TrashInfoEntity;
+import com.bigbro.killbill.v1.domain.entity.trash.TrashCategory;
+import com.bigbro.killbill.v1.domain.entity.trash.TrashInfo;
 import com.bigbro.killbill.v1.domain.request.trash.info.TrashInfoRequest;
 import com.bigbro.killbill.v1.domain.response.trash.TrashInfoResponse;
 import com.bigbro.killbill.v1.exception.DataNotFoundException;
@@ -27,18 +27,18 @@ public class TrashInfoServiceImpl implements TrashInfoService {
     @Override
     @Transactional(readOnly = true)
     public List<TrashInfoResponse> getTrashInfoByCategoryId(Long categoryId) {
-        TrashCategoryEntity trashCategoryEntity = trashCategoryRepository.findById(categoryId).orElseThrow(() -> new DataNotFoundException(KillBillResponseCode.NOT_FOUND_DATA, "해당 쓰레기 카테고리가 존재하지 않습니다."));
-        List<TrashInfoEntity> trashInfoEntityList = trashInfoRepository.findTrashInfoEntitiesByTrashCategoryEntity(trashCategoryEntity);
+        TrashCategory trashCategory = trashCategoryRepository.findById(categoryId).orElseThrow(() -> new DataNotFoundException(KillBillResponseCode.NOT_FOUND_DATA, "해당 쓰레기 카테고리가 존재하지 않습니다."));
+        List<TrashInfo> trashInfoList = trashInfoRepository.findTrashInfoEntitiesByTrashCategory(trashCategory);
 
-        return trashInfoEntityList.stream().map(TrashInfoResponse::from).toList();
+        return trashInfoList.stream().map(TrashInfoResponse::from).toList();
     }
 
     @Override
     @Transactional
     public TrashInfoResponse createTrashInfo(TrashInfoRequest trashInfoRequest) {
-        TrashCategoryEntity trashCategoryEntity = trashCategoryRepository.findById(trashInfoRequest.getTrashCategoryId()).orElseThrow(() -> new DataNotFoundException(KillBillResponseCode.NOT_FOUND_DATA, "해당 쓰레기 카테고리가 존재하지 않습니다."));
-        TrashInfoEntity trashInfoEntity = trashInfoRepository.save(TrashInfoEntity.of(trashInfoRequest, trashCategoryEntity));
+        TrashCategory trashCategory = trashCategoryRepository.findById(trashInfoRequest.getTrashCategoryId()).orElseThrow(() -> new DataNotFoundException(KillBillResponseCode.NOT_FOUND_DATA, "해당 쓰레기 카테고리가 존재하지 않습니다."));
+        TrashInfo trashInfo = trashInfoRepository.save(TrashInfo.of(trashInfoRequest, trashCategory));
 
-        return TrashInfoResponse.from(trashInfoEntity);
+        return TrashInfoResponse.from(trashInfo);
     }
 }

--- a/src/test/java/com/bigbro/killbill/v1/api/trash/can/TrashCanContentsApiTest.java
+++ b/src/test/java/com/bigbro/killbill/v1/api/trash/can/TrashCanContentsApiTest.java
@@ -1,0 +1,62 @@
+package com.bigbro.killbill.v1.api.trash.can;
+
+import com.bigbro.killbill.v1.annotation.TestController;
+import com.bigbro.killbill.v1.config.DocumentConfig;
+import com.bigbro.killbill.v1.domain.request.trash.can.TrashCanContentsRequest;
+import com.bigbro.killbill.v1.service.trash.can.TrashCanContentsService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.resourceDetails;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@TestController
+@WebMvcTest(TrashCanContentsApi.class)
+class TrashCanContentsApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TrashCanContentsService trashCanContentsService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("쓰레기통 내용물 적립")
+    void createTrashCanContents() throws Exception {
+        TrashCanContentsRequest trashCanContentsRequest = TrashCanContentsRequest.builder()
+                .trashCount(1L)
+                .trashInfoId(1L)
+                .build();
+
+        this.mockMvc.perform(RestDocumentationRequestBuilders.post("/api/v1/trash-can-contents")
+                        .contextPath("/api")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(trashCanContentsRequest))
+                )
+                .andExpect(status().isCreated())
+                .andDo(document("create-trash-can-contents",
+                                resourceDetails().tags("쓰레기통 내용물 생성"),
+                                DocumentConfig.getDocumentRequest(),
+                                DocumentConfig.getDocumentResponse(),
+                                responseFields(
+                                        fieldWithPath("code").description("응답 코드"),
+                                        fieldWithPath("title").description("응답 코드 별 클라이언트 노출 제목"),
+                                        fieldWithPath("message").description("응답 코드 별 클라이언트 노출 메세지"),
+                                        fieldWithPath("data").description("응답 데이터 없음")
+                                )
+                        )
+                );
+    }
+}

--- a/src/test/java/com/bigbro/killbill/v1/service/trash/impl/TrashCanContentsServiceImplTest.java
+++ b/src/test/java/com/bigbro/killbill/v1/service/trash/impl/TrashCanContentsServiceImplTest.java
@@ -1,0 +1,67 @@
+package com.bigbro.killbill.v1.service.trash.impl;
+
+import com.bigbro.killbill.v1.domain.entity.trash.TrashInfo;
+import com.bigbro.killbill.v1.domain.entity.user.User;
+import com.bigbro.killbill.v1.enumType.LoginType;
+import com.bigbro.killbill.v1.repository.trash.can.TrashCanContentsRepository;
+import com.bigbro.killbill.v1.repository.trash.info.TrashInfoRepository;
+import com.bigbro.killbill.v1.repository.user.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+
+@ExtendWith(MockitoExtension.class)
+class TrashCanContentsServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private TrashInfoRepository trashInfoRepository;
+
+    @Mock
+    private TrashCanContentsRepository trashCanContentsRepository;
+
+    @InjectMocks
+    private TrashCanContentsServiceImpl trashCanContentsService;
+
+    @Test
+    @DisplayName("쓰레기통 내용물 적립")
+    void createTrashCanContents() {
+        User user = User.builder()
+                .userId(1L)
+                .loginType(LoginType.GOOGLE)
+                .build();
+
+        TrashInfo trashInfo =
+                TrashInfo.builder()
+                        .trashInfoId(1L)
+                        .name("플라스틱")
+                        .size(1)
+                        .weight(1D)
+                        .refund(1)
+                        .carbonEmissionPerGram(1D)
+                        .build();
+
+        given(userRepository.findById(1L)).willReturn(Optional.ofNullable(user));
+        given(trashInfoRepository.findById(1L)).willReturn(Optional.ofNullable(trashInfo));
+
+        assertThat(userRepository).isNotNull();
+        assertThat(trashInfoRepository).isNotNull();
+        assertThat(trashInfo.getName()).isEqualTo("플라스틱");
+
+        then(userRepository.findById(1L)).equals(user);
+        then(trashInfoRepository.findById(1L)).equals(trashInfo);
+    }
+
+}

--- a/src/test/java/com/bigbro/killbill/v1/service/trash/impl/TrashInfoServiceImplTest.java
+++ b/src/test/java/com/bigbro/killbill/v1/service/trash/impl/TrashInfoServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.bigbro.killbill.v1.service.trash.impl;
 
+import com.bigbro.killbill.v1.common.KillBillResponseCode;
 import com.bigbro.killbill.v1.domain.entity.trash.TrashCategory;
 import com.bigbro.killbill.v1.domain.entity.trash.TrashInfo;
 import com.bigbro.killbill.v1.domain.response.trash.TrashInfoResponse;
@@ -14,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -45,16 +47,25 @@ public class TrashInfoServiceImplTest {
                 .trashCategoryName("플라스틱")
                 .build();
 
-        List<TrashInfo> trashInfoList = List.of(
-                TrashInfo.builder()
-                        .trashInfoId(1L)
-                        .name("플라스틱")
-                        .size(1)
-                        .weight(1D)
-                        .refund(1)
-                        .carbonEmissionPerGram(1D)
-                        .build()
-        );
+        TrashInfo plastic = TrashInfo.builder()
+                .trashInfoId(1L)
+                .name("플라스틱")
+                .size(1)
+                .weight(1D)
+                .refund(1)
+                .carbonEmissionPerGram(1D)
+                .build();
+        TrashInfo can = TrashInfo.builder()
+                .trashInfoId(2L)
+                .name("캔")
+                .size(2)
+                .weight(3D)
+                .refund(10)
+                .carbonEmissionPerGram(2D)
+                .build();
+
+        List<TrashInfo> trashInfoList = List.of(plastic, can);
+
         List<TrashInfoResponse> trashInfoResponseList = trashInfoList.stream().map(TrashInfoResponse::from).toList();
 
         given(trashCategoryRepository.findById(1L)).willReturn(Optional.ofNullable(trashCategory));
@@ -64,6 +75,15 @@ public class TrashInfoServiceImplTest {
         List<TrashInfo> trashInfoEntities = trashInfoRepository.findTrashInfoEntitiesByTrashCategory(trashCategory);
 
         assertThat(findCategoryEntity).isNotNull();
+        assertThat(trashInfoEntities)
+                .filteredOn("name", "캔")
+                .containsOnly(can);
+        assertThat(trashInfoEntities)
+                .extracting("name", "refund")
+                .contains(
+                        tuple("플라스틱", 1),
+                        tuple("캔", 10)
+                );
 
         then(findCategoryEntity).equals(trashCategory);
         then(trashInfoEntities).equals(trashInfoResponseList);
@@ -76,7 +96,7 @@ public class TrashInfoServiceImplTest {
 
         DataNotFoundException exception = assertThrows(DataNotFoundException.class, () -> trashInfoService.getTrashInfoByCategoryId(1L));
 
-        assertEquals("4000", exception.getCode());
+        assertEquals(KillBillResponseCode.NOT_FOUND_DATA.getCode(), exception.getCode());
         assertEquals("해당 쓰레기 카테고리가 존재하지 않습니다.", exception.getMessage());
     }
 

--- a/src/test/java/com/bigbro/killbill/v1/service/trash/impl/TrashInfoServiceImplTest.java
+++ b/src/test/java/com/bigbro/killbill/v1/service/trash/impl/TrashInfoServiceImplTest.java
@@ -58,7 +58,7 @@ public class TrashInfoServiceImplTest {
         List<TrashInfoResponse> trashInfoResponseList = trashInfoList.stream().map(TrashInfoResponse::from).toList();
 
         given(trashCategoryRepository.findById(1L)).willReturn(Optional.ofNullable(trashCategory));
-        given(trashInfoRepository.findTrashInfoEntitiesByTrashCategory(1L)).willReturn(trashInfoList);
+        given(trashInfoRepository.findTrashInfoEntitiesByTrashCategory(trashCategory)).willReturn(trashInfoList);
 
         Optional<TrashCategory> findCategoryEntity = trashCategoryRepository.findById(1L);
         List<TrashInfo> trashInfoEntities = trashInfoRepository.findTrashInfoEntitiesByTrashCategory(trashCategory);

--- a/src/test/java/com/bigbro/killbill/v1/service/trash/impl/TrashInfoServiceImplTest.java
+++ b/src/test/java/com/bigbro/killbill/v1/service/trash/impl/TrashInfoServiceImplTest.java
@@ -1,7 +1,7 @@
 package com.bigbro.killbill.v1.service.trash.impl;
 
-import com.bigbro.killbill.v1.domain.entity.trash.TrashCategoryEntity;
-import com.bigbro.killbill.v1.domain.entity.trash.TrashInfoEntity;
+import com.bigbro.killbill.v1.domain.entity.trash.TrashCategory;
+import com.bigbro.killbill.v1.domain.entity.trash.TrashInfo;
 import com.bigbro.killbill.v1.domain.response.trash.TrashInfoResponse;
 import com.bigbro.killbill.v1.exception.DataNotFoundException;
 import com.bigbro.killbill.v1.repository.trash.category.TrashCategoryRepository;
@@ -40,13 +40,13 @@ public class TrashInfoServiceImplTest {
     @Test
     @DisplayName("쓰레기 정보 목록 불러오기")
     void findTrashInfoList() {
-        TrashCategoryEntity trashCategoryEntity = TrashCategoryEntity.builder()
+        TrashCategory trashCategory = TrashCategory.builder()
                 .trashCategoryId(1L)
                 .trashCategoryName("플라스틱")
                 .build();
 
-        List<TrashInfoEntity> trashInfoEntityList = List.of(
-                TrashInfoEntity.builder()
+        List<TrashInfo> trashInfoList = List.of(
+                TrashInfo.builder()
                         .trashInfoId(1L)
                         .name("플라스틱")
                         .size(1)
@@ -55,17 +55,17 @@ public class TrashInfoServiceImplTest {
                         .carbonEmissionPerGram(1D)
                         .build()
         );
-        List<TrashInfoResponse> trashInfoResponseList = trashInfoEntityList.stream().map(TrashInfoResponse::from).toList();
+        List<TrashInfoResponse> trashInfoResponseList = trashInfoList.stream().map(TrashInfoResponse::from).toList();
 
-        given(trashCategoryRepository.findById(1L)).willReturn(Optional.ofNullable(trashCategoryEntity));
-        given(trashInfoRepository.findTrashInfoEntitiesByTrashCategoryEntity(trashCategoryEntity)).willReturn(trashInfoEntityList);
+        given(trashCategoryRepository.findById(1L)).willReturn(Optional.ofNullable(trashCategory));
+        given(trashInfoRepository.findTrashInfoEntitiesByTrashCategory(1L)).willReturn(trashInfoList);
 
-        Optional<TrashCategoryEntity> findCategoryEntity = trashCategoryRepository.findById(1L);
-        List<TrashInfoEntity> trashInfoEntities = trashInfoRepository.findTrashInfoEntitiesByTrashCategoryEntity(trashCategoryEntity);
+        Optional<TrashCategory> findCategoryEntity = trashCategoryRepository.findById(1L);
+        List<TrashInfo> trashInfoEntities = trashInfoRepository.findTrashInfoEntitiesByTrashCategory(trashCategory);
 
         assertThat(findCategoryEntity).isNotNull();
 
-        then(findCategoryEntity).equals(trashCategoryEntity);
+        then(findCategoryEntity).equals(trashCategory);
         then(trashInfoEntities).equals(trashInfoResponseList);
     }
 


### PR DESCRIPTION
- 쓰레기통에 쓰레기 넣는 로직
- Entity suffix 제거
이유
1.  불필요 하다는 생각이 들어서
2. 여러 프로젝트 참고해서 봤을 때 안쓰는 케이스가 많아서
3. 보기가 더 깔끔하다는 생각

추후 로그 테이블 생성 PR에 로그 넣는 로직  추가할 예정

참고
쓰레기통 내용물이랑 쓰레기 로그랑 별도로 테이블 분리
이유:
/**
 * 쓰레기통 로그를 이용 안하고 별도로 쓰레기통 내용물 테이블을 둔 이유
 * 로그를 이용하게 될 경우 이미 비워진 쓰레기 내용물까지 포함하고 있어
 * 나중에 많은 쓰레기 로그가 존재할 경우 조회 성능에 문제 생길걸 대비하여
 * 현 쓰레기통 상태값 만을 위한 값을 별도로 둠.
 */

