### PR TITLE
resolver를 통한 유저정보 공통화

### DIFF
--- a/wwooss-api/src/main/java/com/bigbro/wwooss/v1/api/alarm/AlarmApi.java
+++ b/wwooss-api/src/main/java/com/bigbro/wwooss/v1/api/alarm/AlarmApi.java
@@ -28,7 +28,6 @@ public class AlarmApi {
 
     @GetMapping
     public ResponseEntity<WwoossResponse<List<AlarmResponse>>> getAlarmList(UserCredential userCredential) {
-        // TODO: userId 넣기
         return WwoossResponseUtil.responseOkAddData(alarmService.getAlarmList(userCredential.getUserId()));
     }
 

--- a/wwooss-api/src/main/java/com/bigbro/wwooss/v1/api/alarm/AlarmApi.java
+++ b/wwooss-api/src/main/java/com/bigbro/wwooss/v1/api/alarm/AlarmApi.java
@@ -2,6 +2,7 @@ package com.bigbro.wwooss.v1.api.alarm;
 
 import com.bigbro.wwooss.v1.dto.request.alarm.AlarmOnOffRequest;
 import com.bigbro.wwooss.v1.dto.request.alarm.AlarmRequest;
+import com.bigbro.wwooss.v1.dto.request.user.UserCredential;
 import com.bigbro.wwooss.v1.dto.response.alarm.AlarmResponse;
 import com.bigbro.wwooss.v1.response.WwoossResponse;
 import com.bigbro.wwooss.v1.response.WwoossResponseUtil;
@@ -26,9 +27,9 @@ public class AlarmApi {
     }
 
     @GetMapping
-    public ResponseEntity<WwoossResponse<List<AlarmResponse>>> getAlarmList() {
+    public ResponseEntity<WwoossResponse<List<AlarmResponse>>> getAlarmList(UserCredential userCredential) {
         // TODO: userId 넣기
-        return WwoossResponseUtil.responseOkAddData(alarmService.getAlarmList(1L));
+        return WwoossResponseUtil.responseOkAddData(alarmService.getAlarmList(userCredential.getUserId()));
     }
 
     @PatchMapping("/{alarm-id}")

--- a/wwooss-api/src/main/java/com/bigbro/wwooss/v1/common/UserArgumentResolver.java
+++ b/wwooss-api/src/main/java/com/bigbro/wwooss/v1/common/UserArgumentResolver.java
@@ -28,12 +28,11 @@ public class UserArgumentResolver implements HandlerMethodArgumentResolver {
             throw new RuntimeException("Servlet Request Not Found");
         }
 
-        Object credentials = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-
+        TokenInfo tokenInfo = (TokenInfo) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         return UserCredential.builder()
-                .userId(((TokenInfo) credentials).getUserId())
-                .userRole(((TokenInfo) credentials).getUserRole())
-                .userEmail(((TokenInfo) credentials).getUserEmail())
+                .userId(tokenInfo.getUserId())
+                .userRole(tokenInfo.getUserRole())
+                .userEmail(tokenInfo.getUserEmail())
                 .build();
     }
 

--- a/wwooss-api/src/main/java/com/bigbro/wwooss/v1/common/UserArgumentResolver.java
+++ b/wwooss-api/src/main/java/com/bigbro/wwooss/v1/common/UserArgumentResolver.java
@@ -1,0 +1,40 @@
+package com.bigbro.wwooss.v1.common;
+
+import com.bigbro.wwooss.v1.dto.request.user.UserCredential;
+import com.bigbro.wwooss.v1.security.TokenInfo;
+import java.util.Objects;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class UserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(UserCredential.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+
+        if (Objects.isNull(request)) {
+            throw new RuntimeException("Servlet Request Not Found");
+        }
+
+        Object credentials = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        return UserCredential.builder()
+                .userId(((TokenInfo) credentials).getUserId())
+                .userRole(((TokenInfo) credentials).getUserRole())
+                .userEmail(((TokenInfo) credentials).getUserEmail())
+                .build();
+    }
+
+}

--- a/wwooss-api/src/main/java/com/bigbro/wwooss/v1/config/WebConfig.java
+++ b/wwooss-api/src/main/java/com/bigbro/wwooss/v1/config/WebConfig.java
@@ -1,0 +1,16 @@
+package com.bigbro.wwooss.v1.config;
+
+import com.bigbro.wwooss.v1.common.UserArgumentResolver;
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new UserArgumentResolver());
+    }
+}

--- a/wwooss-api/src/main/java/com/bigbro/wwooss/v1/dto/request/user/UserCredential.java
+++ b/wwooss-api/src/main/java/com/bigbro/wwooss/v1/dto/request/user/UserCredential.java
@@ -1,0 +1,22 @@
+package com.bigbro.wwooss.v1.dto.request.user;
+
+import com.bigbro.wwooss.v1.enumType.UserRole;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class UserCredential {
+    Long userId;
+    String userEmail;
+    UserRole userRole;
+
+    public static UserCredential of(Long userId, String userEmail, UserRole userRole) {
+        return UserCredential.builder()
+                .userId(userId)
+                .userEmail(userEmail)
+                .userRole(userRole)
+                .build();
+
+    }
+}

--- a/wwooss-api/src/main/java/com/bigbro/wwooss/v1/security/CustomAuthenticationProcessingFilter.java
+++ b/wwooss-api/src/main/java/com/bigbro/wwooss/v1/security/CustomAuthenticationProcessingFilter.java
@@ -23,6 +23,8 @@ import java.util.List;
 @Slf4j
 public class CustomAuthenticationProcessingFilter extends AbstractAuthenticationProcessingFilter {
 
+    private final String ROLE_PREFIX = "ROLE_";
+
     private static final List<String> UNFILTERED_URIS = List.of("/api/v1/auth/login", "/api/v1/auth/register",
             "/api/v1/health");
     private final TokenProvider tokenProvider;
@@ -45,10 +47,9 @@ public class CustomAuthenticationProcessingFilter extends AbstractAuthentication
         String token = parseBearerToken(requestTokenHeader);
         TokenInfo tokenInfo = tokenProvider.getTokenInfo(token);
 
-        String userEmail = tokenInfo.getUserEmail();
         Collection<? extends GrantedAuthority> authorities = getAuthorities(tokenInfo.getUserRole());
 
-        return new UsernamePasswordAuthenticationToken(userEmail, token, authorities);
+        return new UsernamePasswordAuthenticationToken(tokenInfo, token, authorities);
     }
 
     @Override
@@ -62,7 +63,7 @@ public class CustomAuthenticationProcessingFilter extends AbstractAuthentication
     }
 
     private Collection<? extends GrantedAuthority> getAuthorities(UserRole userRole) {
-        return List.of(new SimpleGrantedAuthority(userRole.toString()));
+        return List.of(new SimpleGrantedAuthority(ROLE_PREFIX + userRole.toString()));
     }
 
 }

--- a/wwooss-api/src/main/java/com/bigbro/wwooss/v1/security/SecurityConfig.java
+++ b/wwooss-api/src/main/java/com/bigbro/wwooss/v1/security/SecurityConfig.java
@@ -45,7 +45,8 @@ public class SecurityConfig {
                         .antMatchers("/v1/auth/**").permitAll()
                         .antMatchers("/v1/health").permitAll()
                         .antMatchers("/v1/**").hasRole("USER")
-                        .anyRequest().hasRole("ADMIN"))
+                        .anyRequest().hasRole("ADMIN")
+                )
                 .addFilterBefore(new CustomAuthenticationProcessingFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class);
         return httpSecurity.build();
     }

--- a/wwooss-api/src/main/java/com/bigbro/wwooss/v1/service/auth/impl/AuthServiceImpl.java
+++ b/wwooss-api/src/main/java/com/bigbro/wwooss/v1/service/auth/impl/AuthServiceImpl.java
@@ -106,18 +106,18 @@ public class AuthServiceImpl implements AuthService {
                 userRegistrationRequest.getCountry(),
                 userRegistrationRequest.getRegion()
         );
+        User registeredUser = userRepository.save(user);
 
-        String accessToken = tokenProvider.generateToken(user, "access");
-        String refreshToken = tokenProvider.generateToken(user, "refresh");
+        String accessToken = tokenProvider.generateToken(registeredUser, "access");
+        String refreshToken = tokenProvider.generateToken(registeredUser, "refresh");
 
         if (LoginType.EMAIL == user.getLoginType()) {
             String encodedPassword = passwordEncoder.encode(user.getPassword());
-            user = User.of(user, encodedPassword, refreshToken);
+            registeredUser.updateTokenAndPsw(encodedPassword, refreshToken);
         } else {
-            user = User.of(user, refreshToken);
+            registeredUser.updateRefreshToken(refreshToken);
         }
 
-        userRepository.save(user);
 
         return TokenResponse.builder()
                 .accessToken(accessToken)

--- a/wwooss-api/src/test/java/com/bigbro/wwooss/v1/annotation/WithMockCustomUser.java
+++ b/wwooss-api/src/test/java/com/bigbro/wwooss/v1/annotation/WithMockCustomUser.java
@@ -1,0 +1,18 @@
+package com.bigbro.wwooss.v1.annotation;
+
+import com.bigbro.wwooss.v1.enumType.UserRole;
+import com.bigbro.wwooss.v1.factory.WithMockCustomUserSecurityContextFactory;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+    String userId() default "1";
+
+    String userEmail() default "wwoosss@";
+
+    UserRole userRole() default UserRole.USER;
+
+}

--- a/wwooss-api/src/test/java/com/bigbro/wwooss/v1/api/alarm/AlarmApiTest.java
+++ b/wwooss-api/src/test/java/com/bigbro/wwooss/v1/api/alarm/AlarmApiTest.java
@@ -10,6 +10,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.bigbro.wwooss.v1.annotation.TestController;
+import com.bigbro.wwooss.v1.annotation.WithMockCustomUser;
 import com.bigbro.wwooss.v1.config.DocumentConfig;
 import com.bigbro.wwooss.v1.dto.request.alarm.AlarmOnOffRequest;
 import com.bigbro.wwooss.v1.dto.request.alarm.AlarmRequest;
@@ -40,6 +41,7 @@ public class AlarmApiTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
+    @WithMockCustomUser
     @DisplayName("알람 목록 가져오기")
     void getAlarmList() throws Exception {
         List<AlarmResponse> alarmResponses =

--- a/wwooss-api/src/test/java/com/bigbro/wwooss/v1/api/alarm/AlarmApiTest.java
+++ b/wwooss-api/src/test/java/com/bigbro/wwooss/v1/api/alarm/AlarmApiTest.java
@@ -11,13 +11,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.bigbro.wwooss.v1.annotation.TestController;
 import com.bigbro.wwooss.v1.config.DocumentConfig;
-import com.bigbro.wwooss.v1.dto.CarbonEmissionByTrashCategory;
-import com.bigbro.wwooss.v1.dto.RefundByTrashCategory;
 import com.bigbro.wwooss.v1.dto.request.alarm.AlarmOnOffRequest;
 import com.bigbro.wwooss.v1.dto.request.alarm.AlarmRequest;
-import com.bigbro.wwooss.v1.dto.request.user.UpdatePushConsentRequest;
 import com.bigbro.wwooss.v1.dto.response.alarm.AlarmResponse;
-import com.bigbro.wwooss.v1.dto.response.trash.EmptyTrashResultResponse;
 import com.bigbro.wwooss.v1.enumType.DayOfWeek;
 import com.bigbro.wwooss.v1.service.alarm.AlarmService;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/wwooss-api/src/test/java/com/bigbro/wwooss/v1/factory/WithMockCustomUserSecurityContextFactory.java
+++ b/wwooss-api/src/test/java/com/bigbro/wwooss/v1/factory/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,36 @@
+package com.bigbro.wwooss.v1.factory;
+
+import com.bigbro.wwooss.v1.annotation.WithMockCustomUser;
+import com.bigbro.wwooss.v1.enumType.UserRole;
+import com.bigbro.wwooss.v1.security.TokenInfo;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithMockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockCustomUser annotation) {
+        final SecurityContext context = SecurityContextHolder.createEmptyContext();
+        TokenInfo tokenInfo =
+                TokenInfo.builder()
+                        .userId(Long.parseLong(annotation.userId()))
+                        .userEmail(annotation.userEmail())
+                        .userRole(annotation.userRole())
+                        .build();
+        Collection<? extends GrantedAuthority> authorities = getAuthorities(tokenInfo.getUserRole());
+        final Authentication auth = new UsernamePasswordAuthenticationToken(tokenInfo, null, authorities);
+        context.setAuthentication(auth);
+        return context;
+    }
+
+    private Collection<? extends GrantedAuthority> getAuthorities(UserRole userRole) {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + userRole.toString()));
+    }
+}

--- a/wwooss-domain-rds/src/main/java/com/bigbro/wwooss/v1/entity/user/User.java
+++ b/wwooss-domain-rds/src/main/java/com/bigbro/wwooss/v1/entity/user/User.java
@@ -128,4 +128,13 @@ public class User extends BaseEntity {
         this.pushConsent = pushConsent;
     }
 
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public void updateTokenAndPsw(String refreshToken, String password) {
+        this.refreshToken = refreshToken;
+        this.password = password;
+    }
+
 }


### PR DESCRIPTION
**작업**
1. sign-up bug 수정
회원가입 시 토큰에 userId 값 없이 생성

- **원인** 
유저 생성 전에 token을 생성 시키는 로직

- **해결**
유저 생성 후 토큰 생성 시키고 업데이트 형식

- **추후 개선**
이와 같은 이슈가 발생한 이유는 sign-up에 sign-in 기능이 있다고 생각
단일 책임 원칙필요
sign-up - 회원등록
sign-in - 입장권 발급
sign-up 후 완료되면 클라에서 별도로 sign-in api 던지도록 고려

2. resolver를 통한 유저 정보 공통화
- userInfo에 대한 정보를 security context 내부에서 꺼내와 controller param으로 담아주는 공통화 작업
도입 테스트로 alram 조회에만 담음. 다음 작업으로 다른 api 모두 적용할 예정