### PR TITLE
주간 리포트 수정

### DIFF
--- a/wwooss-api/src/main/java/com/bigbro/wwooss/v1/api/report/WeeklyReportApi.java
+++ b/wwooss-api/src/main/java/com/bigbro/wwooss/v1/api/report/WeeklyReportApi.java
@@ -9,9 +9,11 @@ import com.bigbro.wwooss.v1.service.report.WeeklyReportService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,9 +24,10 @@ public class WeeklyReportApi {
     private final WeeklyReportService weeklyReportService;
 
     @GetMapping
-    public ResponseEntity<WwoossResponse<WeeklyReportListResponse>> getWeeklyReportList(Pageable pageable,
+    public ResponseEntity<WwoossResponse<WeeklyReportListResponse>> getWeeklyReportList(@RequestParam @Nullable String date, Pageable pageable,
             UserCredential userCredential) {
-        return WwoossResponseUtil.responseOkAddData(weeklyReportService.getWeeklyReport(userCredential.getUserId(), pageable));
+        return WwoossResponseUtil.responseOkAddData(weeklyReportService.getWeeklyReport(date,
+                userCredential.getUserId(), pageable));
     }
 
     @GetMapping("/{weekly-report-id}")

--- a/wwooss-api/src/main/java/com/bigbro/wwooss/v1/api/trash/log/TrashLogApi.java
+++ b/wwooss-api/src/main/java/com/bigbro/wwooss/v1/api/trash/log/TrashLogApi.java
@@ -1,5 +1,6 @@
 package com.bigbro.wwooss.v1.api.trash.log;
 
+import com.bigbro.wwooss.v1.dto.request.user.UserCredential;
 import com.bigbro.wwooss.v1.dto.response.trash.TrashLogListResponse;
 import com.bigbro.wwooss.v1.response.WwoossResponse;
 import com.bigbro.wwooss.v1.response.WwoossResponseUtil;
@@ -23,7 +24,8 @@ public class TrashLogApi {
     @GetMapping
     private ResponseEntity<WwoossResponse<TrashLogListResponse>> getTrashLog(
             @RequestParam @Nullable String date,
-            Pageable pageable) {
-        return WwoossResponseUtil.responseOkAddData(trashLogService.getTrashLogList(1L, date, pageable));
+            Pageable pageable, UserCredential userCredential) {
+        return WwoossResponseUtil.responseOkAddData(trashLogService.getTrashLogList(userCredential.getUserId(), date,
+                pageable));
     }
 }

--- a/wwooss-api/src/main/java/com/bigbro/wwooss/v1/dto/request/trash/can/TrashCanContentsRequest.java
+++ b/wwooss-api/src/main/java/com/bigbro/wwooss/v1/dto/request/trash/can/TrashCanContentsRequest.java
@@ -10,7 +10,7 @@ import javax.validation.constraints.NotNull;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class TrashCanContentsRequest {
 
-    @NotNull(message = "쓰레기 이름은 필수입니다.")
+    @NotNull(message = "쓰레기 수는 필수입니다.")
     private Long trashCount;
 
     @NotNull(message = "쓰레기 크기는 필수입니다. min:0, max: 10")

--- a/wwooss-api/src/main/java/com/bigbro/wwooss/v1/dto/response/report/WeeklyReportDetailResponse.java
+++ b/wwooss-api/src/main/java/com/bigbro/wwooss/v1/dto/response/report/WeeklyReportDetailResponse.java
@@ -14,9 +14,6 @@ public class WeeklyReportDetailResponse {
     // report id
     private Long weeklyReportId;
 
-    // 주차
-    private Long weekNumber;
-
     // 출석 요일 [1 ~ 7 / 월 ~ 일]
     private List<Integer> attendanceRecord;
 
@@ -44,7 +41,6 @@ public class WeeklyReportDetailResponse {
     public static WeeklyReportDetailResponse from(WeeklyReport weeklyReport) {
         return WeeklyReportDetailResponse.builder()
                 .weeklyReportId(weeklyReport.getWeeklyReportId())
-                .weekNumber(weeklyReport.getWeekNumber())
                 .attendanceRecord(weeklyReport.getAttendanceRecord())
                 .weeklyCarbonEmission(weeklyReport.getWeeklyCarbonEmission())
                 .weeklyRefund(weeklyReport.getWeeklyRefund())

--- a/wwooss-api/src/main/java/com/bigbro/wwooss/v1/dto/response/report/WeeklyReportResponse.java
+++ b/wwooss-api/src/main/java/com/bigbro/wwooss/v1/dto/response/report/WeeklyReportResponse.java
@@ -1,5 +1,6 @@
 package com.bigbro.wwooss.v1.dto.response.report;
 
+import com.bigbro.wwooss.v1.dto.WeekInfo;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,16 +12,16 @@ public class WeeklyReportResponse {
 
     private long weeklyReportId;
 
-    private long weekNumber;
+    private WeekInfo weekInfo;
 
     private LocalDateTime fromDate;
 
     private LocalDateTime toDate;
 
-    public static WeeklyReportResponse of(long weeklyReportId, long weekNumber, LocalDateTime fromDate, LocalDateTime toDate) {
+    public static WeeklyReportResponse of(long weeklyReportId, WeekInfo weekInfo, LocalDateTime fromDate, LocalDateTime toDate) {
         return WeeklyReportResponse.builder()
                 .weeklyReportId(weeklyReportId)
-                .weekNumber(weekNumber)
+                .weekInfo(weekInfo)
                 .fromDate(fromDate)
                 .toDate(toDate)
                 .build();

--- a/wwooss-api/src/main/java/com/bigbro/wwooss/v1/service/auth/impl/AuthServiceImpl.java
+++ b/wwooss-api/src/main/java/com/bigbro/wwooss/v1/service/auth/impl/AuthServiceImpl.java
@@ -113,7 +113,7 @@ public class AuthServiceImpl implements AuthService {
 
         if (LoginType.EMAIL == user.getLoginType()) {
             String encodedPassword = passwordEncoder.encode(user.getPassword());
-            registeredUser.updateTokenAndPsw(encodedPassword, refreshToken);
+            registeredUser.updateTokenAndPsw(refreshToken,encodedPassword);
         } else {
             registeredUser.updateRefreshToken(refreshToken);
         }

--- a/wwooss-api/src/main/java/com/bigbro/wwooss/v1/service/report/WeeklyReportService.java
+++ b/wwooss-api/src/main/java/com/bigbro/wwooss/v1/service/report/WeeklyReportService.java
@@ -8,12 +8,16 @@ public interface WeeklyReportService {
 
     /**
      * 주간 리포트 목록 조회
+     * @param date 유형
+     * null :  전체 데이터
+     * YYYY-MM : 해당 연,월 데이터
+     * YYYY : 해당 연 데이터
      * @param userId 유저 ID
      * @param pageable 페이지 정보
      *
      * @return WeeklyReportListResponse
      */
-    WeeklyReportListResponse getWeeklyReport(Long userId, Pageable pageable);
+    WeeklyReportListResponse getWeeklyReport(String date, Long userId, Pageable pageable);
 
     /**
      * 주간 리포트 상세 조회

--- a/wwooss-api/src/main/java/com/bigbro/wwooss/v1/service/report/impl/WeeklyReportServiceImpl.java
+++ b/wwooss-api/src/main/java/com/bigbro/wwooss/v1/service/report/impl/WeeklyReportServiceImpl.java
@@ -31,12 +31,14 @@ public class WeeklyReportServiceImpl implements WeeklyReportService {
 
     @Transactional(readOnly = true)
     @Override
-    public WeeklyReportListResponse getWeeklyReport(Long userId, Pageable pageable) {
+    public WeeklyReportListResponse getWeeklyReport(String date, Long userId, Pageable pageable) {
         User user = userRepository.findById(userId).orElseThrow(() -> new DataNotFoundException(WwoossResponseCode.NOT_FOUND_DATA, "존재하지 않는 유저입니다."));
         Slice<WeeklyReport> weeklyReport = weeklyReportRepository.findWeeklyReportByUser(user, pageable);
 
         List<WeeklyReportResponse> weeklyReportResponseList = weeklyReport.getContent().stream().map((report) -> {
             // -1 이유 : 0주차가 아닌 1주차부터 시작
+            // user 생성날짜 기준 주차 계산
+            // weekNumber : ((오늘 날짜 - 가입 날짜) / 7) 올림
             LocalDateTime weekNumberDate = user.getCreatedAt().plusWeeks(report.getWeekNumber() - 1);
 
             // N주차 기간 구하기

--- a/wwooss-api/src/main/java/com/bigbro/wwooss/v1/service/report/impl/WeeklyReportServiceImpl.java
+++ b/wwooss-api/src/main/java/com/bigbro/wwooss/v1/service/report/impl/WeeklyReportServiceImpl.java
@@ -1,5 +1,6 @@
 package com.bigbro.wwooss.v1.service.report.impl;
 
+import com.bigbro.wwooss.v1.dto.WeekInfo;
 import com.bigbro.wwooss.v1.dto.response.report.WeeklyReportDetailResponse;
 import com.bigbro.wwooss.v1.dto.response.report.WeeklyReportListResponse;
 import com.bigbro.wwooss.v1.dto.response.report.WeeklyReportResponse;
@@ -10,6 +11,7 @@ import com.bigbro.wwooss.v1.repository.report.WeeklyReportRepository;
 import com.bigbro.wwooss.v1.repository.user.UserRepository;
 import com.bigbro.wwooss.v1.response.WwoossResponseCode;
 import com.bigbro.wwooss.v1.service.report.WeeklyReportService;
+import com.bigbro.wwooss.v1.utils.DateUtil;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -17,6 +19,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.sql.Date;
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -29,24 +32,25 @@ public class WeeklyReportServiceImpl implements WeeklyReportService {
 
     private final UserRepository userRepository;
 
+    private final DateUtil dateUtil;
+
     @Transactional(readOnly = true)
     @Override
     public WeeklyReportListResponse getWeeklyReport(String date, Long userId, Pageable pageable) {
         User user = userRepository.findById(userId).orElseThrow(() -> new DataNotFoundException(WwoossResponseCode.NOT_FOUND_DATA, "존재하지 않는 유저입니다."));
-        Slice<WeeklyReport> weeklyReport = weeklyReportRepository.findWeeklyReportByUser(user, pageable);
+        Slice<WeeklyReport> weeklyReport = weeklyReportRepository.findWeeklyReportByUserAtDate(date, user, pageable);
 
         List<WeeklyReportResponse> weeklyReportResponseList = weeklyReport.getContent().stream().map((report) -> {
-            // -1 이유 : 0주차가 아닌 1주차부터 시작
-            // user 생성날짜 기준 주차 계산
-            // weekNumber : ((오늘 날짜 - 가입 날짜) / 7) 올림
-            LocalDateTime weekNumberDate = user.getCreatedAt().plusWeeks(report.getWeekNumber() - 1);
+            WeekInfo weekInfo = dateUtil.getCurrentWeekOfMonth(dateUtil.convertToDate(report.getWeeklyDate()));
 
-            // N주차 기간 구하기
-            DayOfWeek dayOfWeek = weekNumberDate.getDayOfWeek();
-            LocalDateTime fromDate = weekNumberDate.minusDays(dayOfWeek.ordinal());
-            LocalDateTime toDate = weekNumberDate.plusDays(( 6 - dayOfWeek.ordinal()));
+            // 월요일, 일요일 날짜
+            int monday = dateUtil.getDayAtWeekOfMonth(weekInfo.getYear(), weekInfo.getMonth(), weekInfo.getWeekOfMonth(), 2);
+            int sunday = dateUtil.getDayAtWeekOfMonth(weekInfo.getYear(), weekInfo.getMonth(), weekInfo.getWeekOfMonth(), 1);
 
-            return WeeklyReportResponse.of(report.getWeeklyReportId(), report.getWeekNumber(), fromDate, toDate);
+            LocalDateTime fromDate = LocalDateTime.of(weekInfo.getYear(), weekInfo.getMonth(), monday, 0, 0);
+            LocalDateTime toDate = LocalDateTime.of(weekInfo.getYear(), weekInfo.getMonth(), sunday, 0, 0);
+
+            return WeeklyReportResponse.of(report.getWeeklyReportId(), weekInfo, fromDate, toDate);
         }).toList();
 
         return WeeklyReportListResponse.of(weeklyReport.hasNext(), weeklyReportResponseList);

--- a/wwooss-api/src/main/java/com/bigbro/wwooss/v1/service/report/impl/WeeklyReportServiceImpl.java
+++ b/wwooss-api/src/main/java/com/bigbro/wwooss/v1/service/report/impl/WeeklyReportServiceImpl.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.sql.Date;
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
+import java.util.Calendar;
 import java.util.List;
 
 @Service
@@ -44,11 +45,11 @@ public class WeeklyReportServiceImpl implements WeeklyReportService {
             WeekInfo weekInfo = dateUtil.getCurrentWeekOfMonth(dateUtil.convertToDate(report.getWeeklyDate()));
 
             // 월요일, 일요일 날짜
-            int monday = dateUtil.getDayAtWeekOfMonth(weekInfo.getYear(), weekInfo.getMonth(), weekInfo.getWeekOfMonth(), 2);
-            int sunday = dateUtil.getDayAtWeekOfMonth(weekInfo.getYear(), weekInfo.getMonth(), weekInfo.getWeekOfMonth(), 1);
+            Calendar monday = dateUtil.getDayAtWeekOfMonth(weekInfo.getYear(), weekInfo.getMonth(), weekInfo.getWeekOfMonth(), 2);
+            Calendar sunday = dateUtil.getDayAtWeekOfMonth(weekInfo.getYear(), weekInfo.getMonth(), weekInfo.getWeekOfMonth(), 1);
 
-            LocalDateTime fromDate = LocalDateTime.of(weekInfo.getYear(), weekInfo.getMonth(), monday, 0, 0);
-            LocalDateTime toDate = LocalDateTime.of(weekInfo.getYear(), weekInfo.getMonth(), sunday, 0, 0);
+            LocalDateTime fromDate = LocalDateTime.of(monday.get(Calendar.YEAR), monday.get(Calendar.MONTH) + 1, monday.get(Calendar.DATE), 0, 0);
+            LocalDateTime toDate = LocalDateTime.of(sunday.get(Calendar.YEAR), sunday.get(Calendar.MONTH) + 1, sunday.get(Calendar.DATE), 0, 0);
 
             return WeeklyReportResponse.of(report.getWeeklyReportId(), weekInfo, fromDate, toDate);
         }).toList();

--- a/wwooss-api/src/test/java/com/bigbro/wwooss/v1/api/report/WeeklyReportApiTest.java
+++ b/wwooss-api/src/test/java/com/bigbro/wwooss/v1/api/report/WeeklyReportApiTest.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.bigbro.wwooss.v1.annotation.TestController;
 import com.bigbro.wwooss.v1.annotation.WithMockCustomUser;
+import com.bigbro.wwooss.v1.dto.WeekInfo;
 import com.bigbro.wwooss.v1.dto.response.report.WeeklyReportListResponse;
 import com.bigbro.wwooss.v1.dto.response.report.WeeklyReportResponse;
 import com.bigbro.wwooss.v1.config.DocumentConfig;
@@ -42,7 +43,8 @@ class WeeklyReportApiTest {
     @WithMockCustomUser
     @DisplayName("쓰레기 목록 가져오기")
     void getWeeklyReportList() throws Exception {
-        List<WeeklyReportResponse> weeklyReportResponseList = List.of(WeeklyReportResponse.of(1L, 1L,
+        WeekInfo weekInfo = WeekInfo.of(2024, 4, 1);
+        List<WeeklyReportResponse> weeklyReportResponseList = List.of(WeeklyReportResponse.of(1L, weekInfo,
                 LocalDateTime.now(), LocalDateTime.now()));
         given(weeklyReportService.getWeeklyReport(any(), any(), any())).willReturn(WeeklyReportListResponse.of(false,
                 weeklyReportResponseList));
@@ -71,7 +73,9 @@ class WeeklyReportApiTest {
                                         fieldWithPath("data.hasNext").description("다음 페이지 존재"),
                                         fieldWithPath("data.weeklyReportResponseList[].weeklyReportId").description(
                                                 "주간 리포트 ID"),
-                                        fieldWithPath("data.weeklyReportResponseList[].weekNumber").description("N주차"),
+                                        fieldWithPath("data.weeklyReportResponseList[].weekInfo.year").description("조회 연도"),
+                                        fieldWithPath("data.weeklyReportResponseList[].weekInfo.month").description("조회 월"),
+                                        fieldWithPath("data.weeklyReportResponseList[].weekInfo.weekOfMonth").description("N주차"),
                                         fieldWithPath("data.weeklyReportResponseList[].fromDate").description("N주차 "
                                                 + "시작일"),
                                         fieldWithPath("data.weeklyReportResponseList[].toDate").description("N주차 종료일")

--- a/wwooss-api/src/test/java/com/bigbro/wwooss/v1/api/report/WeeklyReportApiTest.java
+++ b/wwooss-api/src/test/java/com/bigbro/wwooss/v1/api/report/WeeklyReportApiTest.java
@@ -44,7 +44,8 @@ class WeeklyReportApiTest {
     void getWeeklyReportList() throws Exception {
         List<WeeklyReportResponse> weeklyReportResponseList = List.of(WeeklyReportResponse.of(1L, 1L,
                 LocalDateTime.now(), LocalDateTime.now()));
-        given(weeklyReportService.getWeeklyReport(any(), any())).willReturn(WeeklyReportListResponse.of(false, weeklyReportResponseList));
+        given(weeklyReportService.getWeeklyReport(any(), any(), any())).willReturn(WeeklyReportListResponse.of(false,
+                weeklyReportResponseList));
 
         this.mockMvc.perform(RestDocumentationRequestBuilders.get("/api/v1/weekly-reports")
                         .with(csrf().asHeader())
@@ -59,6 +60,7 @@ class WeeklyReportApiTest {
                                 DocumentConfig.getDocumentRequest(),
                                 DocumentConfig.getDocumentResponse(),
                                 requestParameters(
+                                        parameterWithName("date").description("조회 날짜 : [null / YYYY-MM / YYYY]").optional(),
                                         parameterWithName("page").description("현재 페이지"),
                                         parameterWithName("size").description("한 페이지 당 결과값").optional()
                                 ),

--- a/wwooss-api/src/test/java/com/bigbro/wwooss/v1/service/report/impl/WeeklyReportServiceImplTest.java
+++ b/wwooss-api/src/test/java/com/bigbro/wwooss/v1/service/report/impl/WeeklyReportServiceImplTest.java
@@ -26,6 +26,7 @@ import static org.mockito.BDDMockito.then;
 
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
+import java.util.Calendar;
 import java.util.List;
 import java.util.Optional;
 
@@ -72,11 +73,11 @@ public class WeeklyReportServiceImplTest {
             WeekInfo weekInfo = dateUtil.getCurrentWeekOfMonth(dateUtil.convertToDate(report.getWeeklyDate()));
 
             // 월요일, 일요일 날짜
-            int monday = dateUtil.getDayAtWeekOfMonth(weekInfo.getYear(), weekInfo.getMonth(), weekInfo.getWeekOfMonth(), 2);
-            int sunday = dateUtil.getDayAtWeekOfMonth(weekInfo.getYear(), weekInfo.getMonth(), weekInfo.getWeekOfMonth(), 1);
+            Calendar monday = dateUtil.getDayAtWeekOfMonth(weekInfo.getYear(), weekInfo.getMonth(), weekInfo.getWeekOfMonth(), 2);
+            Calendar sunday = dateUtil.getDayAtWeekOfMonth(weekInfo.getYear(), weekInfo.getMonth(), weekInfo.getWeekOfMonth(), 1);
 
-            LocalDateTime fromDate = LocalDateTime.of(weekInfo.getYear(), weekInfo.getMonth(), monday, 0, 0);
-            LocalDateTime toDate = LocalDateTime.of(weekInfo.getYear(), weekInfo.getMonth(), sunday, 0, 0);
+            LocalDateTime fromDate = LocalDateTime.of(monday.get(Calendar.YEAR), monday.get(Calendar.MONTH) + 1, monday.get(Calendar.DATE), 0, 0);
+            LocalDateTime toDate = LocalDateTime.of(sunday.get(Calendar.YEAR), sunday.get(Calendar.MONTH) + 1, sunday.get(Calendar.DATE), 0, 0);
 
             return WeeklyReportResponse.of(report.getWeeklyReportId(), weekInfo, fromDate, toDate);
         }).toList();

--- a/wwooss-batch/src/main/java/com/bigbro/wwooss/v1/scheduler/ReportScheduler.java
+++ b/wwooss-batch/src/main/java/com/bigbro/wwooss/v1/scheduler/ReportScheduler.java
@@ -32,6 +32,7 @@ public class ReportScheduler {
      * 주간 쓰레기 로그 리포트
      * 매주 월요일 새벽 3시 마다 전주( 월 ~ 일 ) 로그 데이터 리포팅
      */
+//    @Scheduled(cron = "0 28 15 * * *", zone = "Asia/Seoul")
     @Scheduled(cron = "0 0 3 * * 1", zone = "Asia/Seoul")
     public void weeklyReportSchedule() throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException, JobParametersInvalidException, JobRestartException {
 

--- a/wwooss-common/src/main/java/com/bigbro/wwooss/v1/dto/WeekInfo.java
+++ b/wwooss-common/src/main/java/com/bigbro/wwooss/v1/dto/WeekInfo.java
@@ -1,0 +1,24 @@
+package com.bigbro.wwooss.v1.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class WeekInfo {
+
+    private int year;
+
+    private int month;
+
+    private int weekOfMonth;
+
+    public static WeekInfo of(int year, int month, int weekOfMonth) {
+        return WeekInfo.builder()
+                .year(year)
+                .month(month)
+                .weekOfMonth(weekOfMonth)
+                .build();
+    }
+
+}

--- a/wwooss-common/src/main/java/com/bigbro/wwooss/v1/utils/DateUtil.java
+++ b/wwooss-common/src/main/java/com/bigbro/wwooss/v1/utils/DateUtil.java
@@ -34,18 +34,18 @@ public class DateUtil {
      * @param dayOfWeek : 일 ~ 토 [ 1 ~ 7 ]
      * @return N주차 N요일의 며칠
      */
-    public int getDayAtWeekOfMonth(int year, int month, int weekOfMonth, int dayOfWeek) {
+    public Calendar getDayAtWeekOfMonth(int year, int month, int weekOfMonth, int dayOfWeek) {
         Calendar calendar = Calendar.getInstance(Locale.KOREA);
         // 한 주의 시작은 월요일이고, 첫 주에 4일이 포함되어있어야 첫 주 취급 (목/금/토/일)
         calendar.setFirstDayOfWeek(Calendar.MONDAY);
         calendar.setMinimalDaysInFirstWeek(4);
 
         calendar.set(Calendar.YEAR, year);
-        calendar.set(Calendar.MONTH, month + 1); // month 0 부터 시작
+        calendar.set(Calendar.MONTH, month - 1); // month 0 부터 시작
         calendar.set(Calendar.WEEK_OF_MONTH, weekOfMonth);
         calendar.set(Calendar.DAY_OF_WEEK, dayOfWeek);
 
-        return calendar.get(Calendar.DATE);
+        return calendar;
     }
 
     /**

--- a/wwooss-common/src/main/java/com/bigbro/wwooss/v1/utils/DateUtil.java
+++ b/wwooss-common/src/main/java/com/bigbro/wwooss/v1/utils/DateUtil.java
@@ -1,9 +1,15 @@
 package com.bigbro.wwooss.v1.utils;
 
+import com.bigbro.wwooss.v1.dto.WeekInfo;
+import org.springframework.stereotype.Component;
+
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.Locale;
 
+@Component
 public class DateUtil {
 
     public static final String SIMPLE_FORMAT_DATE_TIME = "yyyyMMddHHmmss";
@@ -17,5 +23,71 @@ public class DateUtil {
 
     public static String getCurrentDate(String pattern) {
         return LocalDateTime.now().format(DateTimeFormatter.ofPattern(pattern));
+    }
+
+    /**
+     * N주차, N요일의 일수 구하기
+     *
+     * @param year : 검색 연도
+     * @param month : 검색 월
+     * @param weekOfMonth : N 주차
+     * @param dayOfWeek : 일 ~ 토 [ 1 ~ 7 ]
+     * @return N주차 N요일의 며칠
+     */
+    public int getDayAtWeekOfMonth(int year, int month, int weekOfMonth, int dayOfWeek) {
+        Calendar calendar = Calendar.getInstance(Locale.KOREA);
+        // 한 주의 시작은 월요일이고, 첫 주에 4일이 포함되어있어야 첫 주 취급 (목/금/토/일)
+        calendar.setFirstDayOfWeek(Calendar.MONDAY);
+        calendar.setMinimalDaysInFirstWeek(4);
+
+        calendar.set(Calendar.YEAR, year);
+        calendar.set(Calendar.MONTH, month + 1); // month 0 부터 시작
+        calendar.set(Calendar.WEEK_OF_MONTH, weekOfMonth);
+        calendar.set(Calendar.DAY_OF_WEEK, dayOfWeek);
+
+        return calendar.get(Calendar.DATE);
+    }
+
+    /**
+     * 날짜 N 주차 구하기
+     *
+     * @param date : 검색 날짜
+     * @return year, month, weekOfMonth
+     */
+    public WeekInfo getCurrentWeekOfMonth(Date date) {
+        Calendar calendar = Calendar.getInstance(Locale.KOREA);
+        calendar.setTime(date);
+        int month = calendar.get(Calendar.MONTH) + 1; // calendar에서의 월은 0부터 시작
+        int day = calendar.get(Calendar.DATE);
+        int year = calendar.get(Calendar.YEAR);
+
+        // 한 주의 시작은 월요일이고, 첫 주에 4일이 포함되어있어야 첫 주 취급 (목/금/토/일)
+        calendar.setFirstDayOfWeek(Calendar.MONDAY);
+        calendar.setMinimalDaysInFirstWeek(4);
+
+        int weekOfMonth = calendar.get(Calendar.WEEK_OF_MONTH);
+
+        // 첫 주에 해당하지 않는 주의 경우 전 달 마지막 주차로 계산
+        if (weekOfMonth == 0) {
+            calendar.add(Calendar.DATE, -day); // 전 달의 마지막 날 기준
+            return getCurrentWeekOfMonth(calendar.getTime());
+        }
+
+        // 마지막 주차의 경우
+        if (weekOfMonth == calendar.getActualMaximum(Calendar.WEEK_OF_MONTH)) {
+            calendar.set(Calendar.DATE, calendar.getActualMaximum(Calendar.DATE)); // 이번 달의 마지막 날
+            int lastDaysDayOfWeek = calendar.get(Calendar.DAY_OF_WEEK); // 이번 달 마지막 날의 요일
+
+            // 마지막 날이 월~수 사이이면 다음달 1주차로 계산
+            if (lastDaysDayOfWeek >= Calendar.MONDAY && lastDaysDayOfWeek <= Calendar.WEDNESDAY) {
+                calendar.add(Calendar.DATE, 1); // 마지막 날 + 1일 => 다음달 1일
+                return getCurrentWeekOfMonth(calendar.getTime());
+            }
+        }
+        return WeekInfo.of(year, month, weekOfMonth);
+    }
+
+    public Date convertToDate(LocalDateTime dateToConvert) {
+        return java.sql.Timestamp.valueOf(dateToConvert);
     }
 }

--- a/wwooss-domain-rds/src/main/java/com/bigbro/wwooss/v1/entity/report/WeeklyReport.java
+++ b/wwooss-domain-rds/src/main/java/com/bigbro/wwooss/v1/entity/report/WeeklyReport.java
@@ -4,25 +4,23 @@ import com.bigbro.wwooss.v1.converter.IntegerListConverter;
 import com.bigbro.wwooss.v1.converter.WeeklyTrashListConverter;
 import com.bigbro.wwooss.v1.dto.WeeklyTrashByCategory;
 import com.bigbro.wwooss.v1.dto.WowReport;
-import com.bigbro.wwooss.v1.entity.base.BaseEntity;
 import com.bigbro.wwooss.v1.entity.user.User;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
+import lombok.*;
 import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.CreationTimestamp;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Table(name = "weekly_report")
-@SuperBuilder
 @Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class WeeklyReport extends BaseEntity {
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class WeeklyReport {
 
     @Id
     @Column(name = "weekly_report_id")
@@ -53,10 +51,6 @@ public class WeeklyReport extends BaseEntity {
     @Column(name = "weekly_trash_count")
     private Long weeklyTrashCount;
 
-    @Comment("몇주차")
-    @Column(name = "week_number")
-    private Long weekNumber;
-
     @Comment("전주대비 탄소배출량 증감 / Week On Week")
     @Column(name = "wow_carbon_emission")
     private Double wowCarbonEmission;
@@ -69,6 +63,9 @@ public class WeeklyReport extends BaseEntity {
     @Column(name = "wow_trash_count")
     private Long wowTrashCount;
 
+    @Comment("주간 시작 날짜")
+    private LocalDateTime weeklyDate;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
@@ -78,8 +75,8 @@ public class WeeklyReport extends BaseEntity {
             Double weeklyCarbonEmission,
             Long weeklyRefund,
             Long weeklyTrashCount,
-            Long weekNumber,
             WowReport wowReport,
+            LocalDateTime weeklyDate,
             User user) {
         return WeeklyReport.builder()
                 .attendanceRecord(attendanceRecord)
@@ -87,10 +84,10 @@ public class WeeklyReport extends BaseEntity {
                 .weeklyCarbonEmission(weeklyCarbonEmission)
                 .weeklyRefund(weeklyRefund)
                 .weeklyTrashCount(weeklyTrashCount)
-                .weekNumber(weekNumber)
                 .wowCarbonEmission(wowReport.getWowCarbonEmission())
                 .wowRefund(wowReport.getWowRefund())
                 .wowTrashCount(wowReport.getWowTrashCount())
+                .weeklyDate(weeklyDate)
                 .user(user)
                 .build();
     }

--- a/wwooss-domain-rds/src/main/java/com/bigbro/wwooss/v1/repository/report/WeeklyReportRepository.java
+++ b/wwooss-domain-rds/src/main/java/com/bigbro/wwooss/v1/repository/report/WeeklyReportRepository.java
@@ -2,16 +2,12 @@ package com.bigbro.wwooss.v1.repository.report;
 
 import com.bigbro.wwooss.v1.entity.report.WeeklyReport;
 import com.bigbro.wwooss.v1.entity.user.User;
-import org.springframework.data.domain.Pageable;
+import com.bigbro.wwooss.v1.repository.report.custom.WeeklyReportRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.domain.Slice;
 
 import java.util.Optional;
 
-public interface WeeklyReportRepository extends JpaRepository<WeeklyReport, Long> {
-    WeeklyReport findWeeklyReportByWeekNumber(Long weekNumber);
-
-    Slice<WeeklyReport> findWeeklyReportByUser(User user, Pageable pageable);
+public interface WeeklyReportRepository extends JpaRepository<WeeklyReport, Long>, WeeklyReportRepositoryCustom {
 
     Optional<WeeklyReport> findWeeklyReportByWeeklyReportIdAndUser(long weeklyReportId, User user);
 }

--- a/wwooss-domain-rds/src/main/java/com/bigbro/wwooss/v1/repository/report/custom/WeeklyReportRepositoryCustom.java
+++ b/wwooss-domain-rds/src/main/java/com/bigbro/wwooss/v1/repository/report/custom/WeeklyReportRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.bigbro.wwooss.v1.repository.report.custom;
+
+import com.bigbro.wwooss.v1.entity.report.WeeklyReport;
+import com.bigbro.wwooss.v1.entity.user.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface WeeklyReportRepositoryCustom {
+
+    WeeklyReport findWeeklyReportByUserAtLastWeek(User user);
+
+    Slice<WeeklyReport> findWeeklyReportByUserAtDate(String date, User user, Pageable pageable);
+
+}

--- a/wwooss-domain-rds/src/main/java/com/bigbro/wwooss/v1/repository/report/custom/WeeklyReportRepositoryImpl.java
+++ b/wwooss-domain-rds/src/main/java/com/bigbro/wwooss/v1/repository/report/custom/WeeklyReportRepositoryImpl.java
@@ -73,10 +73,10 @@ public class WeeklyReportRepositoryImpl implements WeeklyReportRepositoryCustom 
         calendar.set(year, month + 1, calendar.getActualMaximum(Calendar.DATE));
         int lastWeek = calendar.get(Calendar.WEEK_OF_MONTH);
 
-        int firstMonday = dateUtil.getDayAtWeekOfMonth(year, month, 1, 2);
-        int lastSunday = dateUtil.getDayAtWeekOfMonth(year, month, lastWeek == 1 ? 4 : 5, 1);
+        Calendar firstMonday = dateUtil.getDayAtWeekOfMonth(year, month, 1, 2);
+        Calendar lastSunday = dateUtil.getDayAtWeekOfMonth(year, month, lastWeek == 1 ? 4 : 5, 1);
 
-        return weeklyReport.weeklyDate.between(LocalDateTime.of(year, month, firstMonday, 0, 0),
-                LocalDateTime.of(year, month, lastSunday, 23, 59));
+        return weeklyReport.weeklyDate.between(LocalDateTime.of(firstMonday.get(Calendar.YEAR), firstMonday.get(Calendar.MONTH) + 1, firstMonday.get(Calendar.DATE), 0, 0),
+                LocalDateTime.of(lastSunday.get(Calendar.YEAR), lastSunday.get(Calendar.MONTH), lastSunday.get(Calendar.DATE), 23, 59));
     }
 }

--- a/wwooss-domain-rds/src/main/java/com/bigbro/wwooss/v1/repository/report/custom/WeeklyReportRepositoryImpl.java
+++ b/wwooss-domain-rds/src/main/java/com/bigbro/wwooss/v1/repository/report/custom/WeeklyReportRepositoryImpl.java
@@ -70,13 +70,13 @@ public class WeeklyReportRepositoryImpl implements WeeklyReportRepositoryCustom 
     // 예) 2023/02/01 (목) => 1월 마지막 주 이지만 2월임.
     private BooleanExpression searchYearAndMonth(int year, int month) {
         Calendar calendar = Calendar.getInstance();
-        calendar.set(year, month + 1, calendar.getActualMaximum(Calendar.DATE));
+        calendar.set(year, month - 1, calendar.getActualMaximum(Calendar.DATE));
         int lastWeek = calendar.get(Calendar.WEEK_OF_MONTH);
 
         Calendar firstMonday = dateUtil.getDayAtWeekOfMonth(year, month, 1, 2);
         Calendar lastSunday = dateUtil.getDayAtWeekOfMonth(year, month, lastWeek == 1 ? 4 : 5, 1);
 
         return weeklyReport.weeklyDate.between(LocalDateTime.of(firstMonday.get(Calendar.YEAR), firstMonday.get(Calendar.MONTH) + 1, firstMonday.get(Calendar.DATE), 0, 0),
-                LocalDateTime.of(lastSunday.get(Calendar.YEAR), lastSunday.get(Calendar.MONTH), lastSunday.get(Calendar.DATE), 23, 59));
+                LocalDateTime.of(lastSunday.get(Calendar.YEAR), lastSunday.get(Calendar.MONTH) + 1, lastSunday.get(Calendar.DATE), 23, 59));
     }
 }

--- a/wwooss-domain-rds/src/main/java/com/bigbro/wwooss/v1/repository/report/custom/WeeklyReportRepositoryImpl.java
+++ b/wwooss-domain-rds/src/main/java/com/bigbro/wwooss/v1/repository/report/custom/WeeklyReportRepositoryImpl.java
@@ -1,0 +1,82 @@
+package com.bigbro.wwooss.v1.repository.report.custom;
+
+import com.bigbro.wwooss.v1.dto.WeekInfo;
+import com.bigbro.wwooss.v1.entity.report.WeeklyReport;
+import com.bigbro.wwooss.v1.entity.user.User;
+import com.bigbro.wwooss.v1.utils.DateUtil;
+import com.bigbro.wwooss.v1.utils.PagingUtil;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Calendar;
+import java.util.Date;
+
+import static com.bigbro.wwooss.v1.entity.report.QWeeklyReport.weeklyReport;
+
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class WeeklyReportRepositoryImpl implements WeeklyReportRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    private final DateUtil dateUtil;
+
+    @Override
+    public WeeklyReport findWeeklyReportByUserAtLastWeek(User user) {
+        JPAQuery<WeeklyReport> weeklyReportJPAQuery = jpaQueryFactory.selectFrom(weeklyReport)
+                .where(searchLastWeek().and(weeklyReport.user.eq(user)));
+        return weeklyReportJPAQuery.fetchFirst();
+    }
+
+    @Override
+    public Slice<WeeklyReport> findWeeklyReportByUserAtDate(String date, User user, Pageable pageable) {
+        JPAQuery<WeeklyReport> weeklyReportJPAQuery = jpaQueryFactory.selectFrom(weeklyReport)
+                .where(weeklyReport.user.eq(user).and(searchDate(date)))
+                .orderBy(weeklyReport.weeklyDate.desc());
+
+        return PagingUtil.getSlice(weeklyReportJPAQuery, pageable);
+    }
+
+    private BooleanExpression searchLastWeek() {
+        LocalDate today = LocalDate.now();
+        LocalDate lastWeekDate = today.minusDays(7);
+
+        return weeklyReport.weeklyDate.between(lastWeekDate.atStartOfDay(), lastWeekDate.atTime(LocalTime.MAX));
+    }
+
+    private BooleanExpression searchDate(String date) {
+        if (StringUtils.isBlank(date)) return null;
+        String[] splitDate = date.split("-");
+
+        return splitDate.length == 1 ? searchYear(Integer.parseInt(splitDate[0]))
+                : searchYearAndMonth(Integer.parseInt(splitDate[0]), Integer.parseInt(splitDate[1]));
+    }
+
+    private BooleanExpression searchYear(int year) {
+        return weeklyReport.weeklyDate.year().eq(year);
+    }
+
+    // 날짜가 전달 혹은 다음 달에 포함될 케이스를 고려해 첫주 월요일 ~ 마지막주 일요일로 조회
+    // 예) 2023/02/01 (목) => 1월 마지막 주 이지만 2월임.
+    private BooleanExpression searchYearAndMonth(int year, int month) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(year, month + 1, calendar.getActualMaximum(Calendar.DATE));
+        int lastWeek = calendar.get(Calendar.WEEK_OF_MONTH);
+
+        int firstMonday = dateUtil.getDayAtWeekOfMonth(year, month, 1, 2);
+        int lastSunday = dateUtil.getDayAtWeekOfMonth(year, month, lastWeek == 1 ? 4 : 5, 1);
+
+        return weeklyReport.weeklyDate.between(LocalDateTime.of(year, month, firstMonday, 0, 0),
+                LocalDateTime.of(year, month, lastSunday, 23, 59));
+    }
+}

--- a/wwooss-domain-rds/src/main/java/com/bigbro/wwooss/v1/repository/trash/log/custom/TrashLogRepositoryImpl.java
+++ b/wwooss-domain-rds/src/main/java/com/bigbro/wwooss/v1/repository/trash/log/custom/TrashLogRepositoryImpl.java
@@ -58,14 +58,14 @@ public class TrashLogRepositoryImpl implements TrashLogRepositoryCustom {
         String[] splitDate = date.split("-");
 
         return splitDate.length == 1 ? searchYear((Integer.parseInt(splitDate[0])))
-                : searchMonthAndDay(Integer.parseInt(splitDate[0]), Integer.parseInt(splitDate[1]));
+                : searchMonthAndMonth(Integer.parseInt(splitDate[0]), Integer.parseInt(splitDate[1]));
     }
 
     private BooleanExpression searchYear(int year) {
         return trashLog.createdAt.year().eq(year);
     }
 
-    private BooleanExpression searchMonthAndDay(int year, int month) {
+    private BooleanExpression searchMonthAndMonth(int year, int month) {
         return trashLog.createdAt.year().eq(year).and(trashLog.createdAt.month().eq(month));
     }
 


### PR DESCRIPTION
날짜에 따른 검색 기능 추가

변경 사항
기존 - 1년을 기준으로하여 N주차를 계산
변경 - 월을 기준으로하여 N주차 계산

기존 - weekNumber를 별도 컬럼으로 저장하여 처리
변경 - 생성날짜 기준으로 조회 시 계산을 통해 클라이언트로 내려줄 예정이기 때문에 해당 컬럼 삭제
- 주의 : Calender를 보통 지양한다는 말이 있기는 하지만 N주차를 계산에 있어 가장 정확하게 잘 계산되기 때문에 선택 